### PR TITLE
wrong package import

### DIFF
--- a/src/main/java/edu/montana/gsoc/msusel/quamoco/verifier/ModelVerifier.java
+++ b/src/main/java/edu/montana/gsoc/msusel/quamoco/verifier/ModelVerifier.java
@@ -57,7 +57,7 @@ import edu.montana.gsoc.msusel.quamoco.graph.node.FactorNode;
 import edu.montana.gsoc.msusel.quamoco.graph.node.Finding;
 import edu.montana.gsoc.msusel.quamoco.graph.node.FindingNode;
 import edu.montana.gsoc.msusel.quamoco.graph.node.Node;
-import edu.montana.gsoc.msusel.quamoco.processor.extents.Extent;
+import edu.montana.gsoc.msusel.quamoco.processor.Extent;
 import edu.montana.gsoc.msusel.quamoco.processor.MetricsContext;
 import edu.montana.gsoc.msusel.quamoco.verifier.config.VerifierConfiguration;
 import edu.uci.ics.jung.graph.DirectedSparseGraph;


### PR DESCRIPTION
_Compile error because of wrong import statement._
_error:_ "import edu.montana.gsoc.msusel.quamoco.processor.**extents**.Extent;"
_corrected to:_ "import edu.montana.gsoc.msusel.quamoco.processor.Extent;"